### PR TITLE
placeholder links, todo items in pageheader

### DIFF
--- a/src/components/CodeEditor/CodeEditor.jsx
+++ b/src/components/CodeEditor/CodeEditor.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { render } from "react-dom";
 import AceEditor from "react-ace";
 import "ace-builds/src-noconflict/theme-github";
 

--- a/src/components/PageHeader/PageHeader.jsx
+++ b/src/components/PageHeader/PageHeader.jsx
@@ -5,6 +5,8 @@ import { BellIcon, MenuIcon, XIcon } from '@heroicons/react/outline'
 import { Link } from 'react-router-dom'
 import './PageHeader.css';
 
+// TODO: the links inside the avatar dropdown are placeholders for now to clear warnings in terminal 
+// TODO: fix the logo covering up hamburger menu on mobile view "shrink the webpage and youll see what I mean" -Jessica could you take a crack at this? 
 
 const navigation = [
   { name: 'My Snips', href: '/userhub', current: true },
@@ -111,7 +113,7 @@ export default function PageHeader(props) {
                           <Menu.Item>
                             {({ active }) => (
                               <a
-                                href="#"
+                                href="/profile"
                                 className={classNames(
                                   active ? 'bg-gray-100' : '',
                                   'block px-4 py-2 text-sm text-gray-700'
@@ -124,7 +126,7 @@ export default function PageHeader(props) {
                           <Menu.Item>
                             {({ active }) => (
                               <a
-                                href="#"
+                                href="/settings"
                                 className={classNames(
                                   active ? 'bg-gray-100' : '',
                                   'block px-4 py-2 text-sm text-gray-700'
@@ -137,7 +139,7 @@ export default function PageHeader(props) {
                           <Menu.Item>
                             {({ active }) => (
                               <a
-                                href="#"
+                                href="/signout"
                                 className={classNames(
                                   active ? 'bg-gray-100' : '',
                                   'block px-4 py-2 text-sm text-gray-700'


### PR DESCRIPTION
Added links to avatar dropdown in page header to clear warnings in terminal 
(/profile, /settings, /signout) - currently no pages or actions setup for this 

Added todo items in pageheader. One for @aikinjess 